### PR TITLE
Scripted sbt2 compatibility, Part 2

### DIFF
--- a/src/sbt-test/sbt-web/multi-module/build.sbt
+++ b/src/sbt-test/sbt-web/multi-module/build.sbt
@@ -1,3 +1,5 @@
+import FileAssertions.*
+
 lazy val a = (project in file("."))
   .enablePlugins(SbtWeb)
   .dependsOn(b)
@@ -27,3 +29,138 @@ lazy val e = (project in file("modules/e"))
   )
 
 lazy val x = (project in file("modules/x"))
+
+// Check for files
+
+//$ exists target/web/public/main/js/a.js
+//$ exists target/web/public/main/lib/b/js/b.js
+//$ exists target/web/public/main/lib/c/js/c.js
+//$ exists target/web/public/main/lib/d/js/d.js
+//$ exists target/web/public/main/lib/e/js/e.js
+//$ exists target/web/public/main/lib/jquery/jquery.js
+TaskKey[Unit]("fileCheckA") := {
+  assertLibrary(target.value, "a", Root)
+  assertLibrary(target.value, "b")
+  assertLibrary(target.value, "c")
+  assertLibrary(target.value, "d")
+  assertLibrary(target.value, "e")
+  assertLibrary(target.value, "jquery", External())
+}
+
+//$ exists modules/b/target/web/public/main/js/b.js
+//$ exists modules/b/target/web/public/main/lib/c/js/c.js
+//$ exists modules/b/target/web/public/main/lib/d/js/d.js
+//$ exists modules/b/target/web/public/main/lib/e/js/e.js
+//$ exists modules/b/target/web/public/main/lib/jquery/jquery.js
+TaskKey[Unit]("fileCheckB") := {
+  assertLibrary((b / target).value , "b", Root)
+  assertLibrary((b / target).value, "c")
+  assertLibrary((b / target).value, "d")
+  assertLibrary((b / target).value, "e")
+  assertLibrary((b / target).value, "jquery", External())
+}
+
+//# c has set import directly
+//$ exists modules/c/target/web/public/main/js/c.js
+//$ exists modules/c/target/web/public/main/js/e.js
+//$ exists modules/c/target/web/public/main/lib/jquery/jquery.js
+TaskKey[Unit]("fileCheckC") := {
+  assertLibrary((c / target).value, "c", Root)
+  assertLibrary((c / target).value, "e", Root)
+  assertLibrary((c / target).value, "jquery", External())
+}
+
+//$ exists modules/d/target/web/public/main/js/d.js
+//$ exists modules/d/target/web/public/main/lib/e/js/e.js
+//$ exists modules/d/target/web/public/main/lib/jquery/jquery.js
+TaskKey[Unit]("fileCheckD") := {
+  assertLibrary((d / target).value, "d", Root)
+  assertLibrary((d / target).value, "e")
+  assertLibrary((d / target).value, "jquery", External())
+}
+//> e/assets
+//
+//$ exists modules/e/target/web/public/main/js/e.js
+//$ exists modules/e/target/web/public/main/lib/jquery/jquery.js
+TaskKey[Unit]("fileCheckE") := {
+  assertLibrary((e / target).value, "e", Root)
+  assertLibrary((e / target).value, "jquery", External())
+}
+//> b/web-assets-test:assets
+//
+//# b has disabled direct modules so we expect lib/b here
+//$ exists modules/b/target/web/public/test/lib/b/js/b.js
+//
+//$ exists modules/b/target/web/public/test/lib/c/js/c.js
+//$ exists modules/b/target/web/public/test/lib/c/js/u.js
+//$ exists modules/b/target/web/public/test/lib/d/js/d.js
+//$ exists modules/b/target/web/public/test/lib/d/js/u.js
+//$ exists modules/b/target/web/public/test/lib/e/js/e.js
+//$ exists modules/b/target/web/public/test/lib/e/js/t.js
+//$ exists modules/b/target/web/public/test/lib/jquery/jquery.js
+TaskKey[Unit]("fileCheckBTest") := {
+  assertLibrary((b / target).value, "b", TestLibrary)
+  assertLibrary((b / target).value, "c", TestLibrary)
+  assertLibrary((b / target).value, "c", TestLibrary, Some("u"))
+  assertLibrary((b / target).value, "d", TestLibrary)
+  assertLibrary((b / target).value, "d", TestLibrary, Some("u"))
+  assertLibrary((b / target).value, "e", TestLibrary)
+  assertLibrary((b / target).value, "e", TestLibrary, Some("t"))
+  assertLibrary((b / target).value, "jquery", External("test"))
+}
+//> c/web-assets-test:assets
+//
+//# c has set import directly
+//$ exists modules/c/target/web/public/test/js/c.js
+//$ exists modules/c/target/web/public/test/js/u.js
+//$ exists modules/c/target/web/public/test/js/e.js
+//$ exists modules/c/target/web/public/test/js/t.js
+//$ exists modules/c/target/web/public/test/lib/jquery/jquery.js
+TaskKey[Unit]("fileCheckCTest") := {
+  assertLibrary((c / target).value, "c", TestRoot)
+  assertLibrary((c / target).value, "c", TestRoot, Some("u"))
+  //assertLibrary((c / target).value, "e", TestRoot)
+  //assertLibrary((c / target).value, "e", TestRoot, Some("t"))
+  assertLibrary((c / target).value, "jquery", External("test"))
+}
+//> d/web-assets-test:assets
+//
+//$ exists modules/d/target/web/public/test/js/d.js
+//$ exists modules/d/target/web/public/test/js/u.js
+//$ exists modules/d/target/web/public/test/lib/e/js/e.js
+//$ exists modules/d/target/web/public/test/lib/e/js/t.js
+//$ exists modules/d/target/web/public/test/lib/jquery/jquery.js
+TaskKey[Unit]("fileCheckDTest") := {
+  assertLibrary((d / target).value, "d", TestRoot)
+  assertLibrary((d / target).value, "d", TestRoot, Some("u"))
+  assertLibrary((d / target).value, "e", TestLibrary)
+  assertLibrary((d / target).value, "e", TestLibrary, Some("t"))
+  assertLibrary((d / target).value, "jquery", External("test"))
+}
+//> e/web-assets-test:assets
+//
+//$ exists modules/e/target/web/public/test/js/e.js
+//$ exists modules/e/target/web/public/test/js/t.js
+//$ exists modules/e/target/web/public/test/lib/jquery/jquery.js
+TaskKey[Unit]("fileCheckETest") := {
+  assertLibrary((e / target).value, "e", TestRoot)
+  assertLibrary((e / target).value, "e", TestRoot, Some("t"))
+  assertLibrary((e / target).value, "jquery", External("test"))
+}
+//# Let's optimize the syncing
+//
+//> set ThisBuild / trackInternalDependencies := TrackLevel.TrackIfMissing
+//
+//> a/assets
+//
+//$ exists target/web/public/main/lib/e/js/e.js
+TaskKey[Unit]("fileCheckATracked") := {
+  assertLibrary(target.value, "e")
+}
+//> e/clean
+//> a/assets
+//
+//$ exists target/web/public/main/lib/e/js/e.js
+TaskKey[Unit]("fileCheckETracked") := {
+  assertLibrary(target.value, "e")
+}

--- a/src/sbt-test/sbt-web/multi-module/build.sbt
+++ b/src/sbt-test/sbt-web/multi-module/build.sbt
@@ -39,7 +39,7 @@ lazy val x = (project in file("modules/x"))
 //$ exists target/web/public/main/lib/e/js/e.js
 //$ exists target/web/public/main/lib/jquery/jquery.js
 TaskKey[Unit]("fileCheckA") := {
-  assertLibrary(target.value, "a", Root)
+  assertLibrary(target.value, "a", Root())
   assertLibrary(target.value, "b")
   assertLibrary(target.value, "c")
   assertLibrary(target.value, "d")
@@ -53,20 +53,19 @@ TaskKey[Unit]("fileCheckA") := {
 //$ exists modules/b/target/web/public/main/lib/e/js/e.js
 //$ exists modules/b/target/web/public/main/lib/jquery/jquery.js
 TaskKey[Unit]("fileCheckB") := {
-  assertLibrary((b / target).value , "b", Root)
+  assertLibrary((b / target).value , "b", Root())
   assertLibrary((b / target).value, "c")
   assertLibrary((b / target).value, "d")
   assertLibrary((b / target).value, "e")
   assertLibrary((b / target).value, "jquery", External())
 }
 
-//# c has set import directly
 //$ exists modules/c/target/web/public/main/js/c.js
 //$ exists modules/c/target/web/public/main/js/e.js
 //$ exists modules/c/target/web/public/main/lib/jquery/jquery.js
 TaskKey[Unit]("fileCheckC") := {
-  assertLibrary((c / target).value, "c", Root)
-  assertLibrary((c / target).value, "e", Root)
+  assertLibrary((c / target).value, "c", Root())
+  assertLibrary((c / target).value, "e", Root())
   assertLibrary((c / target).value, "jquery", External())
 }
 
@@ -74,23 +73,18 @@ TaskKey[Unit]("fileCheckC") := {
 //$ exists modules/d/target/web/public/main/lib/e/js/e.js
 //$ exists modules/d/target/web/public/main/lib/jquery/jquery.js
 TaskKey[Unit]("fileCheckD") := {
-  assertLibrary((d / target).value, "d", Root)
+  assertLibrary((d / target).value, "d", Root())
   assertLibrary((d / target).value, "e")
   assertLibrary((d / target).value, "jquery", External())
 }
-//> e/assets
-//
+
 //$ exists modules/e/target/web/public/main/js/e.js
 //$ exists modules/e/target/web/public/main/lib/jquery/jquery.js
 TaskKey[Unit]("fileCheckE") := {
-  assertLibrary((e / target).value, "e", Root)
+  assertLibrary((e / target).value, "e", Root())
   assertLibrary((e / target).value, "jquery", External())
 }
-//> b/web-assets-test:assets
-//
-//# b has disabled direct modules so we expect lib/b here
-//$ exists modules/b/target/web/public/test/lib/b/js/b.js
-//
+
 //$ exists modules/b/target/web/public/test/lib/c/js/c.js
 //$ exists modules/b/target/web/public/test/lib/c/js/u.js
 //$ exists modules/b/target/web/public/test/lib/d/js/d.js
@@ -99,17 +93,16 @@ TaskKey[Unit]("fileCheckE") := {
 //$ exists modules/b/target/web/public/test/lib/e/js/t.js
 //$ exists modules/b/target/web/public/test/lib/jquery/jquery.js
 TaskKey[Unit]("fileCheckBTest") := {
-  assertLibrary((b / target).value, "b", TestLibrary)
-  assertLibrary((b / target).value, "c", TestLibrary)
-  assertLibrary((b / target).value, "c", TestLibrary, Some("u"))
-  assertLibrary((b / target).value, "d", TestLibrary)
-  assertLibrary((b / target).value, "d", TestLibrary, Some("u"))
-  assertLibrary((b / target).value, "e", TestLibrary)
-  assertLibrary((b / target).value, "e", TestLibrary, Some("t"))
+  assertLibrary((b / target).value, "b", Library("test"))
+  assertLibrary((b / target).value, "c", Library("test"))
+  assertLibrary((b / target).value, "c", Library("test"), Some("u"))
+  assertLibrary((b / target).value, "d", Library("test"))
+  assertLibrary((b / target).value, "d", Library("test"), Some("u"))
+  assertLibrary((b / target).value, "e", Library("test"))
+  assertLibrary((b / target).value, "e", Library("test"), Some("t"))
   assertLibrary((b / target).value, "jquery", External("test"))
 }
-//> c/web-assets-test:assets
-//
+
 //# c has set import directly
 //$ exists modules/c/target/web/public/test/js/c.js
 //$ exists modules/c/target/web/public/test/js/u.js
@@ -117,49 +110,40 @@ TaskKey[Unit]("fileCheckBTest") := {
 //$ exists modules/c/target/web/public/test/js/t.js
 //$ exists modules/c/target/web/public/test/lib/jquery/jquery.js
 TaskKey[Unit]("fileCheckCTest") := {
-  assertLibrary((c / target).value, "c", TestRoot)
-  assertLibrary((c / target).value, "c", TestRoot, Some("u"))
-  //assertLibrary((c / target).value, "e", TestRoot)
-  //assertLibrary((c / target).value, "e", TestRoot, Some("t"))
+  assertLibrary((c / target).value, "c", Root("test"))
+  assertLibrary((c / target).value, "c", Root("test"), Some("u"))
+  assertLibrary((c / target).value, "e", Root("test"))
+  assertLibrary((c / target).value, "e", Root("test"), Some("t"))
   assertLibrary((c / target).value, "jquery", External("test"))
 }
-//> d/web-assets-test:assets
-//
+
 //$ exists modules/d/target/web/public/test/js/d.js
 //$ exists modules/d/target/web/public/test/js/u.js
 //$ exists modules/d/target/web/public/test/lib/e/js/e.js
 //$ exists modules/d/target/web/public/test/lib/e/js/t.js
 //$ exists modules/d/target/web/public/test/lib/jquery/jquery.js
 TaskKey[Unit]("fileCheckDTest") := {
-  assertLibrary((d / target).value, "d", TestRoot)
-  assertLibrary((d / target).value, "d", TestRoot, Some("u"))
-  assertLibrary((d / target).value, "e", TestLibrary)
-  assertLibrary((d / target).value, "e", TestLibrary, Some("t"))
+  assertLibrary((d / target).value, "d", Root("test"))
+  assertLibrary((d / target).value, "d", Root("test"), Some("u"))
+  assertLibrary((d / target).value, "e", Library("test"))
+  assertLibrary((d / target).value, "e", Library("test"), Some("t"))
   assertLibrary((d / target).value, "jquery", External("test"))
 }
-//> e/web-assets-test:assets
-//
+
 //$ exists modules/e/target/web/public/test/js/e.js
 //$ exists modules/e/target/web/public/test/js/t.js
 //$ exists modules/e/target/web/public/test/lib/jquery/jquery.js
 TaskKey[Unit]("fileCheckETest") := {
-  assertLibrary((e / target).value, "e", TestRoot)
-  assertLibrary((e / target).value, "e", TestRoot, Some("t"))
+  assertLibrary((e / target).value, "e", Root("test"))
+  assertLibrary((e / target).value, "e", Root("test"), Some("t"))
   assertLibrary((e / target).value, "jquery", External("test"))
 }
-//# Let's optimize the syncing
-//
-//> set ThisBuild / trackInternalDependencies := TrackLevel.TrackIfMissing
-//
-//> a/assets
-//
+
 //$ exists target/web/public/main/lib/e/js/e.js
 TaskKey[Unit]("fileCheckATracked") := {
   assertLibrary(target.value, "e")
 }
-//> e/clean
-//> a/assets
-//
+
 //$ exists target/web/public/main/lib/e/js/e.js
 TaskKey[Unit]("fileCheckETracked") := {
   assertLibrary(target.value, "e")

--- a/src/sbt-test/sbt-web/multi-module/build.sbt
+++ b/src/sbt-test/sbt-web/multi-module/build.sbt
@@ -53,7 +53,7 @@ TaskKey[Unit]("fileCheckA") := {
 //$ exists modules/b/target/web/public/main/lib/e/js/e.js
 //$ exists modules/b/target/web/public/main/lib/jquery/jquery.js
 TaskKey[Unit]("fileCheckB") := {
-  assertLibrary((b / target).value , "b", Root())
+  assertLibrary((b / target).value, "b", Root())
   assertLibrary((b / target).value, "c")
   assertLibrary((b / target).value, "d")
   assertLibrary((b / target).value, "e")

--- a/src/sbt-test/sbt-web/multi-module/project/FileAssertions.scala
+++ b/src/sbt-test/sbt-web/multi-module/project/FileAssertions.scala
@@ -1,0 +1,33 @@
+import sbt.*
+
+object FileAssertions {
+  def assertLibrary(
+      target: File,
+      id: String,
+      location: LibraryLocation = Library,
+      altName: Option[String] = None
+  ): Unit = {
+    val filename = altName.getOrElse(id)
+    val fileToVerify = location match {
+      case Root =>
+        target / "web" / "public" / "main" / "js" / s"$filename.js"
+      case Library =>
+        target / "web" / "public" / "main" / "lib" / id / "js" / s"$filename.js"
+      case TestRoot =>
+        target / "web" / "public" / "test" / "js" / s"$filename.js"
+      case TestLibrary =>
+        target / "web" / "public" / "test" / "lib" / id / "js" / s"$filename.js"
+      case External(path) =>
+        target / "web" / "public" / path / "lib" / id / s"$filename.js"
+    }
+    //println(fileToVerify.toString)
+    assert(fileToVerify.exists(), s"Could not find $filename.js")
+  }
+}
+
+sealed trait LibraryLocation
+case object Root extends LibraryLocation
+case object Library extends LibraryLocation
+case object TestRoot extends LibraryLocation
+case object TestLibrary extends LibraryLocation
+case class External(path: String = "main") extends LibraryLocation

--- a/src/sbt-test/sbt-web/multi-module/project/FileAssertions.scala
+++ b/src/sbt-test/sbt-web/multi-module/project/FileAssertions.scala
@@ -4,30 +4,23 @@ object FileAssertions {
   def assertLibrary(
       target: File,
       id: String,
-      location: LibraryLocation = Library,
+      location: LibraryLocation = Library(),
       altName: Option[String] = None
   ): Unit = {
     val filename = altName.getOrElse(id)
     val fileToVerify = location match {
-      case Root =>
-        target / "web" / "public" / "main" / "js" / s"$filename.js"
-      case Library =>
-        target / "web" / "public" / "main" / "lib" / id / "js" / s"$filename.js"
-      case TestRoot =>
-        target / "web" / "public" / "test" / "js" / s"$filename.js"
-      case TestLibrary =>
-        target / "web" / "public" / "test" / "lib" / id / "js" / s"$filename.js"
+      case Root(stage) =>
+        target / "web" / "public" / stage / "js" / s"$filename.js"
+      case Library(stage) =>
+        target / "web" / "public" / stage / "lib" / id / "js" / s"$filename.js"
       case External(path) =>
         target / "web" / "public" / path / "lib" / id / s"$filename.js"
     }
-    //println(fileToVerify.toString)
     assert(fileToVerify.exists(), s"Could not find $filename.js")
   }
 }
 
 sealed trait LibraryLocation
-case object Root extends LibraryLocation
-case object Library extends LibraryLocation
-case object TestRoot extends LibraryLocation
-case object TestLibrary extends LibraryLocation
-case class External(path: String = "main") extends LibraryLocation
+case class Root(stage: String = "main") extends LibraryLocation
+case class Library(stage: String = "main") extends LibraryLocation
+case class External(stage: String = "main") extends LibraryLocation

--- a/src/sbt-test/sbt-web/multi-module/test
+++ b/src/sbt-test/sbt-web/multi-module/test
@@ -1,73 +1,33 @@
 > a/assets
-
-$ exists target/web/public/main/js/a.js
-$ exists target/web/public/main/lib/b/js/b.js
-$ exists target/web/public/main/lib/c/js/c.js
-$ exists target/web/public/main/lib/d/js/d.js
-$ exists target/web/public/main/lib/e/js/e.js
-$ exists target/web/public/main/lib/jquery/jquery.js
+> fileCheckA
 
 > b/assets
-
-$ exists modules/b/target/web/public/main/js/b.js
-$ exists modules/b/target/web/public/main/lib/c/js/c.js
-$ exists modules/b/target/web/public/main/lib/d/js/d.js
-$ exists modules/b/target/web/public/main/lib/e/js/e.js
-$ exists modules/b/target/web/public/main/lib/jquery/jquery.js
+> fileCheckB
 
 > c/assets
-
 # c has set import directly
-$ exists modules/c/target/web/public/main/js/c.js
-$ exists modules/c/target/web/public/main/js/e.js
-$ exists modules/c/target/web/public/main/lib/jquery/jquery.js
+> fileCheckC
 
 > d/assets
-
-$ exists modules/d/target/web/public/main/js/d.js
-$ exists modules/d/target/web/public/main/lib/e/js/e.js
-$ exists modules/d/target/web/public/main/lib/jquery/jquery.js
+> fileCheckD
 
 > e/assets
+> fileCheckC
 
-$ exists modules/e/target/web/public/main/js/e.js
-$ exists modules/e/target/web/public/main/lib/jquery/jquery.js
-
-> b/web-assets-test:assets
-
+> b/TestAssets/assets
 # b has disabled direct modules so we expect lib/b here
-$ exists modules/b/target/web/public/test/lib/b/js/b.js
+> fileCheckBTest
 
-$ exists modules/b/target/web/public/test/lib/c/js/c.js
-$ exists modules/b/target/web/public/test/lib/c/js/u.js
-$ exists modules/b/target/web/public/test/lib/d/js/d.js
-$ exists modules/b/target/web/public/test/lib/d/js/u.js
-$ exists modules/b/target/web/public/test/lib/e/js/e.js
-$ exists modules/b/target/web/public/test/lib/e/js/t.js
-$ exists modules/b/target/web/public/test/lib/jquery/jquery.js
-
-> c/web-assets-test:assets
+> c/TestAssets/assets
 
 # c has set import directly
-$ exists modules/c/target/web/public/test/js/c.js
-$ exists modules/c/target/web/public/test/js/u.js
-$ exists modules/c/target/web/public/test/js/e.js
-$ exists modules/c/target/web/public/test/js/t.js
-$ exists modules/c/target/web/public/test/lib/jquery/jquery.js
+> fileCheckCTest
 
-> d/web-assets-test:assets
+> d/TestAssets/assets
+> fileCheckDTest
 
-$ exists modules/d/target/web/public/test/js/d.js
-$ exists modules/d/target/web/public/test/js/u.js
-$ exists modules/d/target/web/public/test/lib/e/js/e.js
-$ exists modules/d/target/web/public/test/lib/e/js/t.js
-$ exists modules/d/target/web/public/test/lib/jquery/jquery.js
-
-> e/web-assets-test:assets
-
-$ exists modules/e/target/web/public/test/js/e.js
-$ exists modules/e/target/web/public/test/js/t.js
-$ exists modules/e/target/web/public/test/lib/jquery/jquery.js
+> e/TestAssets/assets
+> fileCheckETest
 
 # Let's optimize the syncing
 
@@ -75,9 +35,9 @@ $ exists modules/e/target/web/public/test/lib/jquery/jquery.js
 
 > a/assets
 
-$ exists target/web/public/main/lib/e/js/e.js
+> fileCheckATracked
 
 > e/clean
 > a/assets
 
-$ exists target/web/public/main/lib/e/js/e.js
+> fileCheckETracked

--- a/src/sbt-test/sbt-web/multi-module/test
+++ b/src/sbt-test/sbt-web/multi-module/test
@@ -12,7 +12,7 @@
 > fileCheckD
 
 > e/assets
-> fileCheckC
+> fileCheckE
 
 > b/TestAssets/assets
 # b has disabled direct modules so we expect lib/b here

--- a/src/sbt-test/sbt-web/package/build.sbt
+++ b/src/sbt-test/sbt-web/package/build.sbt
@@ -1,3 +1,5 @@
+import FileAssertions.*
+
 lazy val root = (project in file(".")).enablePlugins(SbtWeb)
 
 name := "Web Project"
@@ -8,4 +10,26 @@ crossPaths := false
 
 libraryDependencies += "org.webjars" % "jquery" % "2.0.3-1"
 
-TaskKey[Unit]("extractAssets") := IO.unzip((artifactPath in (Assets, packageBin)).value, file("extracted"))
+TaskKey[Unit]("extractAssets") := IO.unzip(
+  SbtWeb.asFile(((Assets / packageBin) / artifactPath).value, fileConverter.value),
+  file("extracted")
+)
+
+// $ exists target/web-project-0.1-web-assets.jar
+TaskKey[Unit]("fileCheckAssets") := {
+  assertExists(target.value / "web-project-0.1-web-assets.jar")
+}
+
+// $ exists extracted/js/a.js
+// $ exists extracted/lib/jquery/jquery.js
+TaskKey[Unit]("fileCheckExtracted") := {
+  assertExists(baseDirectory.value / "extracted" / "js" / "a.js")
+  assertExists(baseDirectory.value / "extracted" / "lib" / "jquery" / "jquery.js")
+}
+
+// $ exists extracted/public/js/a.js
+// $ exists extracted/public/lib/jquery/jquery.js
+TaskKey[Unit]("fileCheckPublic") := {
+  assertExists(baseDirectory.value / "extracted" / "public" / "js" / "a.js")
+  assertExists(baseDirectory.value / "extracted" / "public" / "lib" / "jquery" / "jquery.js")
+}

--- a/src/sbt-test/sbt-web/package/project/FileAssertions.scala
+++ b/src/sbt-test/sbt-web/package/project/FileAssertions.scala
@@ -1,0 +1,6 @@
+import sbt.*
+
+object FileAssertions {
+  def assertExists(file: File): Unit =
+    assert(file.exists(), s"Could not find ${file.getName}")
+}

--- a/src/sbt-test/sbt-web/package/test
+++ b/src/sbt-test/sbt-web/package/test
@@ -1,7 +1,4 @@
-> compile
-> Assets/compile
 > Assets/package
-#> Web-assets / package
 > fileCheckAssets
 
 > extractAssets

--- a/src/sbt-test/sbt-web/package/test
+++ b/src/sbt-test/sbt-web/package/test
@@ -1,14 +1,15 @@
-> web-assets:package
-$ exists target/web-project-0.1-web-assets.jar
+> compile
+> Assets/compile
+> Assets/package
+#> Web-assets / package
+> fileCheckAssets
 
 > extractAssets
-$ exists extracted/js/a.js
-$ exists extracted/lib/jquery/jquery.js
+> fileCheckExtracted
 
 > 'set Assets / WebKeys.packagePrefix := "public/"'
-> web-assets:package
+> Assets/package
 
 $ delete extracted
 > extractAssets
-$ exists extracted/public/js/a.js
-$ exists extracted/public/lib/jquery/jquery.js
+> fileCheckPublic

--- a/src/sbt-test/sbt-web/publish-webjar/build.sbt
+++ b/src/sbt-test/sbt-web/publish-webjar/build.sbt
@@ -1,3 +1,5 @@
+import FileAssertions.*
+
 lazy val a = (project in file("module/a"))
   .enablePlugins(SbtWeb)
   .settings(
@@ -21,3 +23,19 @@ lazy val c = (project in file("."))
   .settings(
     libraryDependencies += "com.github.sbt.web.test" %% "web-module-b" % "0.1-SNAPSHOT"
   )
+
+//$ exists target/web/web-modules/main/webjars/lib/jquery/jquery.js
+//$ exists target/web/web-modules/main/webjars/lib/web-module-a/js/a.js
+//$ exists target/web/web-modules/main/webjars/lib/web-module-b/js/b.js
+//
+//$ exists target/web/public/main/lib/jquery/jquery.js
+//$ exists target/web/public/main/lib/web-module-a/js/a.js
+//$ exists target/web/public/main/lib/web-module-b/js/b.js
+TaskKey[Unit]("fileCheck") := {
+  assertExists(target.value / "web" / "web-modules" / "main" / "webjars" / "lib" / "jquery" / "jquery.js")
+  assertExists(target.value / "web" / "web-modules" / "main" / "webjars" / "lib" / "web-module-a" / "js" / "a.js")
+  assertExists(target.value / "web" / "web-modules" / "main" / "webjars" / "lib" / "web-module-b" / "js" / "b.js")
+  assertExists(target.value / "web" / "public" / "main" / "lib" / "jquery" / "jquery.js")
+  assertExists(target.value / "web" / "public" / "main" / "lib" / "web-module-a" / "js" / "a.js")
+  assertExists(target.value / "web" / "public" / "main" / "lib" / "web-module-b" / "js" / "b.js")
+}

--- a/src/sbt-test/sbt-web/publish-webjar/project/FileAssertions.scala
+++ b/src/sbt-test/sbt-web/publish-webjar/project/FileAssertions.scala
@@ -1,0 +1,6 @@
+import sbt.*
+
+object FileAssertions {
+  def assertExists(file: File): Unit =
+    assert(file.exists(), s"Could not find ${file.getName}")
+}

--- a/src/sbt-test/sbt-web/publish-webjar/test
+++ b/src/sbt-test/sbt-web/publish-webjar/test
@@ -4,10 +4,4 @@
 
 > assets
 
-$ exists target/web/web-modules/main/webjars/lib/jquery/jquery.js
-$ exists target/web/web-modules/main/webjars/lib/web-module-a/js/a.js
-$ exists target/web/web-modules/main/webjars/lib/web-module-b/js/b.js
-
-$ exists target/web/public/main/lib/jquery/jquery.js
-$ exists target/web/public/main/lib/web-module-a/js/a.js
-$ exists target/web/public/main/lib/web-module-b/js/b.js
+> fileCheck


### PR DESCRIPTION
Adds support for the rest of the scripted tests.

This includes support for:
* multi-module
* publish
* publish-webjar

At the moment this is broken for sbt2.

Towards #255